### PR TITLE
Fixed Linux PIDs casting & added posibility to "disable" check from config.

### DIFF
--- a/PMonitor/PMonitor.Core/AbstractProcessMonitor.cs
+++ b/PMonitor/PMonitor.Core/AbstractProcessMonitor.cs
@@ -58,7 +58,7 @@ namespace PMonitor.Core
 
             try
             {
-                int nbProcessesToMonitor = Int32.Parse(ConfigurationManager.AppSettings[NB_KEY]);
+                Int32.TryParse(ConfigurationManager.AppSettings[NB_KEY], out int nbProcessesToMonitor);
                 for (int i = 1; i <= nbProcessesToMonitor; i++)
                 {
                     string processName =

--- a/PMonitor/PMonitor.Core/Linux/LinuxProcess.cs
+++ b/PMonitor/PMonitor.Core/Linux/LinuxProcess.cs
@@ -187,8 +187,16 @@ namespace PMonitor.Core.Linux
 
                 using (var fileReader = File.OpenText(statFilePath))
                 {
-                    var line = fileReader.ReadToEnd();
-                    return new LinuxProcessStatusFile(line);
+                    try
+                    {
+                        var line = fileReader.ReadToEnd();
+                        return new LinuxProcessStatusFile(line);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(String.Format("Could not parse line for PID {0} because \"{1}\".", pid, ex.Message));
+                        return null;
+                    }
                 }
             }
             catch (Exception)

--- a/PMonitor/PMonitor.Core/Linux/LinuxProcessStatusFile.cs
+++ b/PMonitor/PMonitor.Core/Linux/LinuxProcessStatusFile.cs
@@ -13,16 +13,9 @@ namespace PMonitor.Core.Linux
 
         public LinuxProcessStatusFile(string text)
         {
-            try
-            {
-                string[] textPart = text.Split(' ');
-                Pid = Convert.ToInt16(textPart[0]);
-                FileName = textPart[1];
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Could not parse line" + ex.Message);
-            }
+            string[] textPart = text.Split(' ');
+            Pid = Convert.ToInt32(textPart[0]);
+            FileName = textPart[1];
         }
     }
 }

--- a/PMonitor/PMonitor.Example.Console/App.config
+++ b/PMonitor/PMonitor.Example.Console/App.config
@@ -2,12 +2,13 @@
 <configuration>
   <appSettings>
     <!-- Processes to Monitor -->
-    <add key="PMonitorNbOfProcesses" value="1"/>
+    <add key="PMonitorNbOfProcesses" value="2"/>
     
     <!-- 
     The names and friendlys names of the processes you want to monitor, separated by comma. You can choose the process name 
     from the Windows task manager. In this example, I will chose notepad. In windows, the process name does not contain .exe extension.
     -->
     <add key="PMonitorProcess1" value="notepad,Notepad"/>
+    <add key="PMonitorProcess2" value="notepad2,Notepad2"/>
   </appSettings>
 </configuration>

--- a/PMonitor/PMonitor.Example.Console/Program.cs
+++ b/PMonitor/PMonitor.Example.Console/Program.cs
@@ -19,9 +19,10 @@ namespace PMonitor.Example.Console
             while (true)
             {
                 pm.RefreshInformation();
-                BasicProcessInformation bpi = pm.GetProcessInformation().Single();
-
-                System.Console.WriteLine("{0} Process {1} is {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), bpi.FriendlyName, bpi.State.ToString());
+                foreach (var bpi in pm.GetProcessInformation())
+                {
+                    System.Console.WriteLine("{0} Process {1} is {2}", DateTime.Now.ToString(CultureInfo.InvariantCulture), bpi.FriendlyName, bpi.State.ToString());
+                }
 
                 Thread.Sleep(3000);
             }


### PR DESCRIPTION
- Changed the `AbstractProcessMonitor` so that it can properly handle situations where `PMonitorNbOfProcesses` key in `appSettings` is set to `0` or missing completly. This would be useful when it is desired to disable the check without redeploying the application that uses this library. I encountered a situation where it would have been helpful to disable the check in order to partial restore application functionality until I would figure out the issue causing the library to fail. Leading to the next change:
- Changed the parsing of Linux PIDs from Int16 to Int32. This was causing a series of problems with large PIDs:
   - Could not be converted from String to short as the value is too large to be accommodated in this data type and exceptions was being thrown:
   ![image](https://user-images.githubusercontent.com/13658952/149539329-0ecf7b8d-9b44-466b-9978-c1155ddd09e6.png)
   - This in turn leads to the exception being swallowed allowing the execution to continue creating the `LinuxProcessStatusFile` but without the `Pid` and `FileName` being set at all. Furthermore, the check is done on the `LinuxProcessStatusFile` being instantiated but its properties are never verified.
   ![image](https://user-images.githubusercontent.com/13658952/149539457-7010e036-1958-46d7-bf85-e217bb9098a3.png)
   - Finally, the execution's only path (as I can tell) leads to the last line of code in `GetProcessName` method which attempts to trim the `LinuxProcessStatusFile.FileName` property just to end up in throwing a `NullReferenceException`:
   ![image](https://user-images.githubusercontent.com/13658952/149539519-07f6b6eb-c4b0-4f93-86ce-f851fbcddbf2.png)
- Changed to return `null` when the `LinuxProcessStatusFile` cannot be sucessfully build instead of an object but with invalid values.


